### PR TITLE
Add alternative TypeScript scope

### DIFF
--- a/preferences/file_type_typescript.tmPreferences
+++ b/preferences/file_type_typescript.tmPreferences
@@ -2,7 +2,7 @@
 <plist version="1.0">
   <dict>
     <key>scope</key>
-    <string>source.ts</string>
+    <string>source.ts, source.js.typescript</string>
     <key>settings</key>
     <dict>
       <key>icon</key>


### PR DESCRIPTION
This is the scope that you get when you make a JS Custom configuration called "TypeScript"