### PR TITLE
Feature: Add better support for both JSX and TSX

### DIFF
--- a/preferences/file_type_tsx.tmPreferences
+++ b/preferences/file_type_tsx.tmPreferences
@@ -2,11 +2,11 @@
 <plist version="1.0">
   <dict>
     <key>scope</key>
-    <string>source.jsx, source.js.jsx</string>
+    <string>source.tsx</string>
     <key>settings</key>
     <dict>
       <key>icon</key>
-      <string>file_type_jsx</string>
+      <string>file_type_typescript</string>
     </dict>
   </dict>
 </plist>


### PR DESCRIPTION
With Sublime Text 4's newly added support for JSX out-of-the-box, we can include its `source.jsx` scope with the existing JSX preference.
Additionally, I've created a new TSX preference, which reuses the existing TypeScript icon for now.