### PR TITLE
Add support for ModernFortran package

### DIFF
--- a/preferences/file_type_modern-fortran.tmPreferences
+++ b/preferences/file_type_modern-fortran.tmPreferences
@@ -2,7 +2,7 @@
 <plist version="1.0">
   <dict>
     <key>scope</key>
-    <string>source.modern-fortran</string>
+    <string>source.fortran, source.modern-fortran</string>
     <key>settings</key>
     <dict>
       <key>icon</key>


### PR DESCRIPTION
This assigns the Fortran icon to the `source.fortran` base scope, which is used by an alternative syntax package https://packagecontrol.io/packages/ModernFortran.