### PR TITLE
Add support for Terraform source files

### DIFF
--- a/preferences/file_type_terraform.tmPreferences
+++ b/preferences/file_type_terraform.tmPreferences
@@ -2,7 +2,7 @@
 <plist version="1.0">
   <dict>
     <key>scope</key>
-    <string>text.plain.terraform</string>
+    <string>source.terraform, text.plain.terraform</string>
     <key>settings</key>
     <dict>
       <key>icon</key>


### PR DESCRIPTION
When the Terraform syntax is installed, the regular text icon is displayed for those files.
I think this is what's missing given what sublime text scope for a terraform file is:
```
>>> view.scope_name(view.sel()[0].begin())
'source.terraform comment.line.terraform punctuation.definition.comment.terraform '
```